### PR TITLE
Fixed serialization for ProfilerExtension to prevent serialize() of c…

### DIFF
--- a/Twig/ProfilerExtension.php
+++ b/Twig/ProfilerExtension.php
@@ -6,6 +6,7 @@ use Asm89\Twig\CacheExtension\CacheStrategyInterface;
 use Asm89\Twig\CacheExtension\Extension as Asm89_Extension;
 use EmanueleMinotto\TwigCacheBundle\Strategy\ProfilerStrategy;
 use Exception;
+use Serializable;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
@@ -13,7 +14,7 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 /**
  * {@inheritdoc}
  */
-class ProfilerExtension extends Asm89_Extension implements DataCollectorInterface
+class ProfilerExtension extends Asm89_Extension implements DataCollectorInterface, Serializable
 {
     /**
      * Data about fetchBlock requests.
@@ -108,4 +109,37 @@ class ProfilerExtension extends Asm89_Extension implements DataCollectorInterfac
             'strategyClass' => $this->strategyClass,
         ];
     }
+
+    /**
+     * String representation of object
+     * @link http://php.net/manual/en/serializable.serialize.php
+     * @return string the string representation of the object or null
+     * @since 5.1.0
+     */
+    public function serialize()
+    {
+        return $this->getData();
+    }
+
+    /**
+     * Constructs the object
+     * @link http://php.net/manual/en/serializable.unserialize.php
+     * @param string $serialized <p>
+     * The string representation of the object.
+     * </p>
+     * @return void
+     * @since 5.1.0
+     */
+    public function unserialize($serialized)
+    {
+        $data = unserialize($serialized);
+
+        if(is_array($data)) {
+            $this->fetchBlock = $data['fetchBlock'];
+            $this->generateKey = $data['generateKey'];
+            $this->hits = $data['hits'];
+            $this->strategyClass = $data['strategyClass'];
+        }
+    }
+
 }


### PR DESCRIPTION
I've got lots of 404 for _wdt/{token} (Web Profiler) and figured out, that it will throw an exception when the ProfilerExtension of this bundle will be serialized ("Serialization of closures is not supported"). 

So i added a Serializable-Interface to force only the serialization of getData() and not the whole object. The Web Profiler Toolbar is now working again :)
