### PR TITLE
Profile extension fixed serialization

### DIFF
--- a/Tests/ProfilerExtension/ProfilerExtensionTest.php
+++ b/Tests/ProfilerExtension/ProfilerExtensionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace EmanueleMinotto\TwigCacheBundle\Tests\DependencyInjection;
+
+use EmanueleMinotto\TwigCacheBundle\Tests\AppKernel;
+use EmanueleMinotto\TwigCacheBundle\Twig\ProfilerExtension;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @coversDefaultClass \EmanueleMinotto\TwigCacheBundle\Twig\ProfilerExtension
+ */
+class ProfilerExtensionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Symfony\Component\HttpKernel\Kernel
+     */
+    private $kernel;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->kernel = new AppKernel('TwigCacheExtensionTest', true);
+        $this->kernel->boot();
+    }
+
+    /**
+     * @covers ::load
+     */
+    public function testSerialization()
+    {
+        $container = $this->kernel->getContainer();
+
+        $cacheStrategy = $container->get('twig_cache.strategy.generational');
+        $extension = new ProfilerExtension($cacheStrategy);
+
+        $extension->addFetchBlock('foo', true);
+        $extension->addGenerateKey('generation_key', 123);
+
+        $data = $extension->getData();
+
+        $serializedData = serialize( $extension );
+
+        /** @var ProfilerExtension $unserialized */
+        $unserialized = unserialize($serializedData);
+
+        $this->assertInstanceOf('EmanueleMinotto\TwigCacheBundle\Twig\ProfilerExtension', $unserialized);
+        $dataUnserialized = $unserialized->getData();
+
+        $this->assertEquals($data, $dataUnserialized);
+    }
+
+}

--- a/Tests/ProfilerExtension/ProfilerExtensionTest.php
+++ b/Tests/ProfilerExtension/ProfilerExtensionTest.php
@@ -26,7 +26,8 @@ class ProfilerExtensionTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::load
+     * @covers ::serialize
+     * @covers ::unserialize
      */
     public function testSerialization()
     {

--- a/Tests/ProfilerExtension/ProfilerExtensionTest.php
+++ b/Tests/ProfilerExtension/ProfilerExtensionTest.php
@@ -40,7 +40,7 @@ class ProfilerExtensionTest extends PHPUnit_Framework_TestCase
 
         $data = $extension->getData();
 
-        $serializedData = serialize( $extension );
+        $serializedData = serialize($extension);
 
         /** @var ProfilerExtension $unserialized */
         $unserialized = unserialize($serializedData);
@@ -50,5 +50,4 @@ class ProfilerExtensionTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($data, $dataUnserialized);
     }
-
 }

--- a/Twig/ProfilerExtension.php
+++ b/Twig/ProfilerExtension.php
@@ -6,6 +6,7 @@ use Asm89\Twig\CacheExtension\CacheStrategyInterface;
 use Asm89\Twig\CacheExtension\Extension as Asm89_Extension;
 use EmanueleMinotto\TwigCacheBundle\Strategy\ProfilerStrategy;
 use Exception;
+use Serializable;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
@@ -13,7 +14,7 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 /**
  * {@inheritdoc}
  */
-class ProfilerExtension extends Asm89_Extension implements DataCollectorInterface
+class ProfilerExtension extends Asm89_Extension implements DataCollectorInterface, Serializable
 {
     /**
      * Data about fetchBlock requests.
@@ -108,4 +109,37 @@ class ProfilerExtension extends Asm89_Extension implements DataCollectorInterfac
             'strategyClass' => $this->strategyClass,
         ];
     }
+
+    /**
+     * String representation of object
+     * @link http://php.net/manual/en/serializable.serialize.php
+     * @return string the string representation of the object or null
+     * @since 5.1.0
+     */
+    public function serialize()
+    {
+        return $this->getData();
+    }
+
+    /**
+     * Constructs the object
+     * @link http://php.net/manual/en/serializable.unserialize.php
+     * @param string $serialized <p>
+     * The string representation of the object.
+     * </p>
+     * @return void
+     * @since 5.1.0
+     */
+    public function unserialize($serialized)
+    {
+        $data = unserialize($serialized);
+
+        if(is_array($data)) {
+            $this->fetchBlock = $data['fetchBlock'];
+            $this->generateKey = $data['generateKey'];
+            $this->hits = $data['hits'];
+            $this->strategyClass = $data['strategyClass'];
+        }
+    }
+
 }

--- a/Twig/ProfilerExtension.php
+++ b/Twig/ProfilerExtension.php
@@ -114,7 +114,9 @@ class ProfilerExtension extends Asm89_Extension implements DataCollectorInterfac
      * String representation of object.
      *
      * @link http://php.net/manual/en/serializable.serialize.php
+     *
      * @return string the string representation of the object or null
+     *
      * @since 5.1.0
      */
     public function serialize()
@@ -128,7 +130,9 @@ class ProfilerExtension extends Asm89_Extension implements DataCollectorInterfac
      * @link http://php.net/manual/en/serializable.unserialize.php
      *
      * @param string $serialized
+     *
      * @return void
+     *
      * @since 5.1.0
      */
     public function unserialize($serialized)

--- a/Twig/ProfilerExtension.php
+++ b/Twig/ProfilerExtension.php
@@ -118,7 +118,7 @@ class ProfilerExtension extends Asm89_Extension implements DataCollectorInterfac
      */
     public function serialize()
     {
-        return $this->getData();
+        return serialize( $this->getData() );
     }
 
     /**

--- a/Twig/ProfilerExtension.php
+++ b/Twig/ProfilerExtension.php
@@ -114,9 +114,7 @@ class ProfilerExtension extends Asm89_Extension implements DataCollectorInterfac
      * String representation of object.
      *
      * @link http://php.net/manual/en/serializable.serialize.php
-     *
      * @return string the string representation of the object or null
-     *
      * @since 5.1.0
      */
     public function serialize()
@@ -131,7 +129,6 @@ class ProfilerExtension extends Asm89_Extension implements DataCollectorInterfac
      *
      * @param string $serialized
      * @return void
-     *
      * @since 5.1.0
      */
     public function unserialize($serialized)

--- a/Twig/ProfilerExtension.php
+++ b/Twig/ProfilerExtension.php
@@ -111,35 +111,41 @@ class ProfilerExtension extends Asm89_Extension implements DataCollectorInterfac
     }
 
     /**
-     * String representation of object
+     * String representation of object.
+     *
      * @link http://php.net/manual/en/serializable.serialize.php
+     *
      * @return string the string representation of the object or null
+     *
      * @since 5.1.0
      */
     public function serialize()
     {
-        return serialize( $this->getData() );
+        return serialize($this->getData());
     }
 
     /**
-     * Constructs the object
+     * Constructs the object.
+     *
      * @link http://php.net/manual/en/serializable.unserialize.php
+     *
      * @param string $serialized <p>
-     * The string representation of the object.
-     * </p>
+     *                           The string representation of the object.
+     *                           </p>
+     *
      * @return void
+     *
      * @since 5.1.0
      */
     public function unserialize($serialized)
     {
         $data = unserialize($serialized);
 
-        if(is_array($data)) {
+        if (is_array($data)) {
             $this->fetchBlock = $data['fetchBlock'];
             $this->generateKey = $data['generateKey'];
             $this->hits = $data['hits'];
             $this->strategyClass = $data['strategyClass'];
         }
     }
-
 }

--- a/Twig/ProfilerExtension.php
+++ b/Twig/ProfilerExtension.php
@@ -129,10 +129,7 @@ class ProfilerExtension extends Asm89_Extension implements DataCollectorInterfac
      *
      * @link http://php.net/manual/en/serializable.unserialize.php
      *
-     * @param string $serialized <p>
-     *                           The string representation of the object.
-     *                           </p>
-     *
+     * @param string $serialized
      * @return void
      *
      * @since 5.1.0


### PR DESCRIPTION
I've got lots of 404 for _wdt/{token} (Web Profiler) and figured out, that it will throw an exception when the ProfilerExtension of this bundle will be serialized ("Serialization of closures is not supported").

So i added a Serializable-Interface to force only the serialization of getData() and not the whole object. The Web Profiler Toolbar is now working again :)
