### PR TITLE
Remove inline styles from image

### DIFF
--- a/Resources/views/Collector/asm89_cache.html.twig
+++ b/Resources/views/Collector/asm89_cache.html.twig
@@ -5,7 +5,7 @@
 
 {% block toolbar %}
     {% set icon %}
-        <img style="max-width:20px;max-height:28px;margin-top:4px;margin-bottom:4px" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABuElEQVRYw8WXIUgDYRTHxxhjLIiIiGGYFgwGERGDcNttu7ttsrAxEDENg5hFTIIYDCImk9lkNiwZlkQMIoYFMRoWxCQior8HJxzHJuNuvnvwwoX7fv/3f9/7vrtYbMThOM7SqNccOvL5/GahUFiMBG6a5lwul7uPBI7tacMwHnHgIBIBVH6OgO9SqTSrDsf6NYEj4k4dXiwWs8DfRAD276jCq9VqkqpvBU5+WZaVURVAxacuXOzvqMLp++ov3LV/Sw1O3zNAex4Bn4zhpAq8VqslxG5v9TxfqVWP1YdeuCTt2FCBAzJlt/sFIOoYF/b/ytD3AyfcFLAXP3yYRMB1pVJJBoY3Go04i7SDwMku4idCVY/FuwHhPazPhu37soxZAPgH766E7fs4Cz0HqR74eii4BAfOAvZvD0r2RbcfXOWboFwujwF777PjL/4dLkGVrT7wDuOWUhEgs+0T8MSe0bkPAM34TsRXxk3vUwz793zjZqrBJbD/wTNuLVU4oznvGbcjVbhb/Ym74y+bzWZcFc6llHBvxBvbttPq1dNvS45m2jCtDpeg52fy/xcJvF6vp6g83O02IH4ADypEpyHW030AAAAASUVORK5CYII=" alt="Twig Cache">
+        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABuElEQVRYw8WXIUgDYRTHxxhjLIiIiGGYFgwGERGDcNttu7ttsrAxEDENg5hFTIIYDCImk9lkNiwZlkQMIoYFMRoWxCQior8HJxzHJuNuvnvwwoX7fv/3f9/7vrtYbMThOM7SqNccOvL5/GahUFiMBG6a5lwul7uPBI7tacMwHnHgIBIBVH6OgO9SqTSrDsf6NYEj4k4dXiwWs8DfRAD276jCq9VqkqpvBU5+WZaVURVAxacuXOzvqMLp++ov3LV/Sw1O3zNAex4Bn4zhpAq8VqslxG5v9TxfqVWP1YdeuCTt2FCBAzJlt/sFIOoYF/b/ytD3AyfcFLAXP3yYRMB1pVJJBoY3Go04i7SDwMku4idCVY/FuwHhPazPhu37soxZAPgH766E7fs4Cz0HqR74eii4BAfOAvZvD0r2RbcfXOWboFwujwF777PjL/4dLkGVrT7wDuOWUhEgs+0T8MSe0bkPAM34TsRXxk3vUwz793zjZqrBJbD/wTNuLVU4oznvGbcjVbhb/Ym74y+bzWZcFc6llHBvxBvbttPq1dNvS45m2jCtDpeg52fy/xcJvF6vp6g83O02IH4ADypEpyHW030AAAAASUVORK5CYII=" alt="Twig Cache">
 
         {% set status = (
             (collector.data.fetchBlock|length == 0


### PR DESCRIPTION
Twig Cache image in the Symfony Toolbar displays badly. See:
<img width="147" alt="zrzut ekranu 2016-01-13 16 10 18" src="https://cloud.githubusercontent.com/assets/562536/12298325/cbdddbfe-ba11-11e5-8c8e-5fbaf57d63d3.png">

This PR removes inline styles form image so it can be displayed properly.
