### PR TITLE
Add documentation about PSR-6 adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,27 @@ Step 3: Configuration
 twig_cache:
     service: cache_service # instance of Doctrine\Common\Cache\Cache
 ```
+Another option is to configure one of the PSR-6 Cache pool implementations 
+by changing the default adapter class to the `PsrCacheAdapter`. 
+```yml
+# parameters.yml
+twig_cache.adapter.class: Asm89\Twig\CacheExtension\CacheProvider\PsrCacheAdapter
+```
+After that any cache pool that implements the `CacheItemPoolInterface` is 
+supported. The [`CacheBundle`](https://github.com/php-cache/cache-bundle) will
+allow you to configure the cache pool of your choice. List of predefined pools 
+can be found at: [http://php-cache.readthedocs.io/](http://php-cache.readthedocs.io/)
+
+```yml
+# config.yml
+cache_adapter:
+    providers:
+        twig_apcu:
+            factory: 'cache.factory.apcu'
+
+twig_cache:
+    service: cache.provider.twig_apcu
+```
 
 Usage
 -----

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "asm89/twig-cache-extension": "^1.4"
     },
     "require-dev": {
-        "doctrine/cache": "^1.4",
+        "doctrine/cache": "^1.3",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.6",
         "phpunit/phpunit": "^4.4|^5.0",
         "symfony/framework-bundle": "^2.6|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "asm89/twig-cache-extension": "^1.0"
+        "asm89/twig-cache-extension": "^1.4"
     },
     "require-dev": {
         "doctrine/cache": "^1.4",
@@ -31,6 +31,9 @@
         "psr-4": {
             "EmanueleMinotto\\TwigCacheBundle\\": "."
         }
+    },
+    "suggest": {
+        "cache/adapter-common": "To make use of PSR-6 cache implementation via PsrCacheAdapter."
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
         }
     ],
     "require": {
-        "asm89/twig-cache-extension": "^1.4"
+        "asm89/twig-cache-extension": "^1.3"
     },
     "require-dev": {
-        "doctrine/cache": "^1.3",
+        "doctrine/cache": "^1.4",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.6",
         "phpunit/phpunit": "^4.4|^5.0",
         "symfony/framework-bundle": "^2.6|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         }
     },
     "suggest": {
-        "cache/adapter-common": "To make use of PSR-6 cache implementation via PsrCacheAdapter."
+        "cache/adapter-bundle": "To make use of PSR-6 cache implementation via PsrCacheAdapter.",
+        "cache/cache-bundle": "To easily be able to configure adapters in your Symfony application.",
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
https://github.com/asm89/twig-cache-extension/pull/32 will introduce a new adapter that allows you to configure any cache pool that implements the `CacheItemPoolInterface`. This will introduce a lot of adapters to the Twig caching extension: http://php-cache.readthedocs.io/en/latest/

This documentation PR can be merged once the other PR with the adapter is merged and `1.3.0` of the extension was released.
