### PR TITLE
fix deprecation message.

### DIFF
--- a/DependencyInjection/TwigCacheExtension.php
+++ b/DependencyInjection/TwigCacheExtension.php
@@ -40,6 +40,7 @@ class TwigCacheExtension extends Extension
 
         $loader->load('services.xml');
 
+        $container->getDefinition('twig_cache.extension.parent')->replaceArgument(0, new Reference($config['strategy']));
         $container->getDefinition('twig_cache.extension')->replaceArgument(0, new Reference($config['strategy']));
 
         if ($config['profiler']) {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -2,7 +2,8 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="twig_cache.adapter.class">Asm89\Twig\CacheExtension\CacheProvider\DoctrineCacheAdapter</parameter>
-        <parameter key="twig_cache.extension.class">Asm89\Twig\CacheExtension\Extension</parameter>
+        <parameter key="twig_cache.extension.parent.class">Asm89\Twig\CacheExtension\Extension</parameter>
+        <parameter key="twig_cache.extension.class">EmanueleMinotto\TwigCacheBundle\Twig\ProfilerExtension</parameter>
         <parameter key="twig_cache.strategy.class">Asm89\Twig\CacheExtension\CacheStrategy\IndexedChainingCacheStrategy</parameter>
         <parameter key="twig_cache.strategy.generational.class">Asm89\Twig\CacheExtension\CacheStrategy\GenerationalCacheStrategy</parameter>
         <parameter key="twig_cache.strategy.lifetime.class">Asm89\Twig\CacheExtension\CacheStrategy\LifetimeCacheStrategy</parameter>
@@ -18,6 +19,10 @@
         <service class="%twig_cache.strategy.spl_object_hash_key_generator.class%" id="twig_cache.strategy.spl_object_hash_key_generator" public="false"/>
         <service class="%twig_cache.adapter.class%" id="twig_cache.adapter" public="false">
             <argument id="twig_cache.service" type="service"/>
+        </service>
+        <service class="%twig_cache.extension.parent.class%" id="twig_cache.extension.parent">
+            <tag name="twig.extension"/>
+            <argument id="twig_cache.strategy" type="service"/>
         </service>
         <service class="%twig_cache.extension.class%" id="twig_cache.extension">
             <tag name="twig.extension"/>


### PR DESCRIPTION
> Referencing the ... extension by its name (defined by getName()) is deprecated since 1.26 and will be removed in Twig 2.0. Use the Fully Qualified Extension Class Name instead

We can not  use _getName_ method. 
Also, added registration of parent Extension. 

This PR linked to https://github.com/asm89/twig-cache-extension/pull/37
